### PR TITLE
Upgrade Rust to 1.81 and deps

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   build:
-
+    name: Build
     runs-on: ubuntu-latest
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,7 +617,6 @@ dependencies = [
  "dotenv",
  "env_logger 0.11.3",
  "futures-core",
- "lazy_static",
  "log",
  "pretty_assertions",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "actix-contrib-rest"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8722db8b8aad2e95ed10b59c9df1e6d7d34a48233d62957a16f7817a7d8b01"
+checksum = "fac5d8302e0fbec5df12af257e9813b189fdd27c115d5614e79353f3482101bd"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -71,7 +71,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "ahash",
- "base64 0.22.1",
+ "base64",
  "bitflags 2.5.0",
  "brotli",
  "bytes",
@@ -579,7 +579,7 @@ dependencies = [
  "actix-service",
  "actix-tls",
  "actix-utils",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "cfg-if",
  "cookie",
@@ -647,12 +647,6 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -753,13 +747,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.99"
+version = "1.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
+checksum = "67b9470d453346108f93a59222a9a1a5724db32d0a4727b7ab7ace4b4d822dc9"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
@@ -1405,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown",
 ]
@@ -1417,9 +1411,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "heck"
@@ -1670,9 +1661,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.27.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2498,6 +2489,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2530,6 +2527,9 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -2589,9 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.7.4"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
+checksum = "93334716a037193fac19df402f8571269c84a00852f6a7066b5d2616dcd64d3e"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -2602,11 +2602,10 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.7.4"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
+checksum = "d4d8060b456358185f7d50c55d9b5066ad956956fddec42ee2e8567134a8936e"
 dependencies = [
- "ahash",
  "async-io 1.13.0",
  "async-std",
  "atoi",
@@ -2616,12 +2615,13 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener 2.5.3",
+ "event-listener 5.3.1",
  "futures-channel",
  "futures-core",
  "futures-intrusive",
  "futures-io",
  "futures-util",
+ "hashbrown",
  "hashlink",
  "hex",
  "indexmap",
@@ -2643,27 +2643,27 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.7.4"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
+checksum = "cac0692bcc9de3b073e8d747391827297e075c7710ff6276d9f7a1f3d58c6657"
 dependencies = [
  "proc-macro2",
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 1.0.109",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.7.4"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
+checksum = "1804e8a7c7865599c9c79be146dc8a9fd8cc86935fa641d3ea58e5f0688abaa5"
 dependencies = [
  "async-std",
  "dotenvy",
  "either",
- "heck 0.4.1",
+ "heck 0.5.0",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -2675,19 +2675,19 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 1.0.109",
+ "syn 2.0.66",
  "tempfile",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.7.4"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
+checksum = "64bb4714269afa44aef2755150a0fc19d756fb580a67db8885608cf02f47d06a"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64",
  "bitflags 2.5.0",
  "byteorder",
  "bytes",
@@ -2725,12 +2725,12 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.7.4"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
+checksum = "6fa91a732d854c5d7726349bb4bb879bb9478993ceb764247660aee25f67c2f8"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64",
  "bitflags 2.5.0",
  "byteorder",
  "chrono",
@@ -2764,9 +2764,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.7.4"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
+checksum = "d5b2cf34a45953bfd3daaf3db0f7a7878ab9b7a6b91b422d24a7a9e4c857b680"
 dependencies = [
  "atoi",
  "chrono",
@@ -2780,10 +2780,10 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
+ "serde_urlencoded",
  "sqlx-core",
  "tracing",
  "url",
- "urlencoding",
 ]
 
 [[package]]
@@ -3096,12 +3096,6 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2151,9 +2151,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2163,9 +2163,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2180,9 +2180,9 @@ checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ring"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.7.0"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb9843d84c775696c37d9a418bbb01b932629d01870722c0f13eb3f95e2536d"
+checksum = "d48f96fc3003717aeb9856ca3d02a8c7de502667ad76eeacd830b48d2e91fac4"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.7.0"
+version = "4.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6316df3fa569627c98b12557a8b6ff0674e5be4bb9b5e4ae2550ddb4964ed6"
+checksum = "9180d76e5cc7ccbc4d60a506f2c727730b154010262df5b910eb17dbe4b8cb38"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -218,6 +218,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "impl-more",
  "itoa",
  "language-tags",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ path = "src/main.rs"
 name = "backset"
 
 [dependencies]
-actix-web = "4.7"
+actix-web = "4.9"
 actix-web-validator = "6.0"
-actix-http = "3.7"
+actix-http = "3.9"
 actix-contrib-logger = "0.1"
 actix-contrib-rest = { version = "0.5", features = ["sqlx-postgres"] }
 awc = { version = "3.5", features = ["rustls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ validator = { version = "0.18", features = ["derive"] }
 strum = "0.26"
 strum_macros = "0.26"
 rand = "0.8"
-regex = "1.10"
+regex = "1.11"
 server-env-config = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ clap = { version = "4.5", features = ["derive"] }
 dotenv = "0.15"
 env_logger = "0.11"
 futures-core = "0.3"
-lazy_static = "1.4"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ actix-web = "4.9"
 actix-web-validator = "6.0"
 actix-http = "3.9"
 actix-contrib-logger = "0.1"
-actix-contrib-rest = { version = "0.5", features = ["sqlx-postgres"] }
+actix-contrib-rest = { version = "0.6", features = ["sqlx-postgres"] }
 awc = { version = "3.5", features = ["rustls"] }
 anyhow = "1.0"
 async-once-cell = "0.5"
@@ -31,7 +31,7 @@ log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_valid = "0.21"
-sqlx = { version = "0.7", features = ["runtime-async-std", "tls-native-tls", "postgres", "macros", "chrono"] }
+sqlx = { version = "0.8", features = ["runtime-async-std", "tls-native-tls", "postgres", "macros", "chrono"] }
 thiserror = "1.0"
 validator = { version = "0.18", features = ["derive"] }
 strum = "0.26"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.76-alpine3.19 as build
+FROM rust:1.81-alpine3.20 AS build
 LABEL maintainer="Mariano Ruiz"
 
 RUN apk add --no-cache --purge openssl-dev openssl-libs-static musl-dev libc-dev \
@@ -14,7 +14,7 @@ LABEL build=${BUILD}
 RUN echo "Build: $BUILD" > image_build \
     && echo "UTC: $(date --utc +%FT%R)" >> image_build
 
-FROM alpine:3.18
+FROM alpine:3.20
 
 ENV HOST=0
 

--- a/src/elements/model.rs
+++ b/src/elements/model.rs
@@ -2,22 +2,22 @@ use actix_contrib_rest::db::Tx;
 use actix_contrib_rest::query::QuerySearch;
 use actix_contrib_rest::result::{AppError, Result};
 use chrono::NaiveDateTime;
-use lazy_static::lazy_static;
 use rand::random;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use sqlx::postgres::PgQueryResult;
 use sqlx::types::Json;
+use std::sync::LazyLock;
 use validator::Validate;
 
 use crate::tenants::model::Tenant;
 use crate::utils::reject_created_at;
 
-lazy_static! {
-    // Base64 URL characters (except =) and some others like \~@-.:+
-    static ref ID_VALID: Regex = Regex::new(r"^(?i)[a-z0-9_~@\\/][a-z0-9_\\~@\-\.\:+]*$").unwrap();
-}
+// Base64 URL characters (except =) and some others like \~@-.:+
+static ID_VALID: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(?i)[a-z0-9_~@\\/][a-z0-9_\\~@\-\.\:+]*$").unwrap()
+});
 
 #[derive(Debug, Deserialize, sqlx::FromRow, Serialize, Clone)]
 pub struct Element {

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,16 +1,16 @@
 use actix_web::{get, HttpResponse, Responder};
 use serde_json::json;
+use std::sync::LazyLock;
 
 use crate::BACKSET_VERSION;
 
-lazy_static! {
-    static ref HEALTH_CHECK: String = json!({
+static HEALTH_CHECK: LazyLock<String> = LazyLock::new(|| {
+    json!({
         "status": "UP",
         "service": "backset",
         "version": BACKSET_VERSION,
-    })
-    .to_string();
-}
+    }).to_string()
+});
 
 #[get("")]
 pub async fn health_check_handler() -> impl Responder {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 pub mod app_args;
 pub mod app_cmd;
 pub mod app_server;

--- a/src/tenants/model.rs
+++ b/src/tenants/model.rs
@@ -2,17 +2,15 @@ use actix_contrib_rest::db::Tx;
 use actix_contrib_rest::query::QuerySearch;
 use actix_contrib_rest::result::{AppError, Result};
 use chrono::NaiveDateTime;
-use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgQueryResult;
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::sync::LazyLock;
 use validator::{Validate, ValidationError};
 
-lazy_static! {
-    static ref ID_VALID: Regex = Regex::new(r"^[a-z][a-z0-9\-]+$").unwrap();
-}
+static ID_VALID: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[a-z][a-z0-9\-]+$").unwrap());
 
 #[derive(Debug, Deserialize, sqlx::FromRow, Serialize, Clone)]
 pub struct Tenant {

--- a/tests/backset/main.rs
+++ b/tests/backset/main.rs
@@ -6,7 +6,6 @@ use actix_web::web::Data;
 use async_once_cell::OnceCell;
 use backset::tenants::model::{Tenant, TenantPayload};
 use backset::BACKSET_PORT;
-use lazy_static::lazy_static;
 use log::{error, LevelFilter};
 use rand::random;
 use serde::Serialize;
@@ -14,8 +13,7 @@ use server_env_config::env::Environment;
 use server_env_config::Config;
 use sqlx::Connection;
 use std::process::exit;
-use std::sync::Arc;
-use std::sync::Once;
+use std::sync::{Arc, LazyLock, Once};
 
 mod health_api_tests;
 mod elements_api_tests;
@@ -44,9 +42,9 @@ pub async fn initialize() -> Data<AppState> {
     Data::new(data)
 }
 
-lazy_static! {
-    static ref TENANT_ID_ARC: Arc<OnceCell<(u16, u16, u16)>> = Arc::new(OnceCell::new());
-}
+static TENANT_ID_ARC: LazyLock<Arc<OnceCell<(u16, u16, u16)>>> = LazyLock::new(|| {
+    Arc::new(OnceCell::new())
+});
 
 /// Create a few tenants
 pub async fn initialize_tenant<'a>(state: &Data<AppState>) -> &'a (u16, u16, u16) {


### PR DESCRIPTION
- Upgrade base Rust to 1.81 (should work with 1.80 as well).
- Replace `lazy_static` crate with new `LazyLock` type to initialize static values.
- Upgrade Docker Alpine to 3.20.
- Upgrade Actix, SQLx and minor deps.